### PR TITLE
Add basic Russian i18n

### DIFF
--- a/frontend/__tests__/i18n/i18n.spec.ts
+++ b/frontend/__tests__/i18n/i18n.spec.ts
@@ -1,0 +1,20 @@
+import { init, t, applyTranslations } from "../../src/ts/i18n";
+import { describe, it, expect, beforeEach } from "vitest";
+
+describe("i18n", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("loads russian strings", async () => {
+    await init("ru");
+    expect(t("about")).toBe("О сайте");
+  });
+
+  it("applies translations to DOM", async () => {
+    await init("ru");
+    document.body.innerHTML = '<span data-i18n="about"></span>';
+    applyTranslations(document.body);
+    expect(document.querySelector('span')!.textContent).toBe("О сайте");
+  });
+});

--- a/frontend/src/html/pages/404.html
+++ b/frontend/src/html/pages/404.html
@@ -3,10 +3,10 @@
     <div class="image"></div>
     <div class="side">
       <div class="title">404</div>
-      <div>Ooops! Looks like this page or resource doesn't exist.</div>
+      <div data-i18n="pageNotFound">Ooops! Looks like this page or resource doesn't exist.</div>
       <a href="/" class="button" router-link>
         <i class="fas fa-home"></i>
-        Go Home
+        <span data-i18n="goHome">Go Home</span>
       </a>
     </div>
   </div>

--- a/frontend/src/html/pages/login.html
+++ b/frontend/src/html/pages/login.html
@@ -8,7 +8,7 @@
   <div class="register side">
     <div class="title">
       <i class="fas fa-user-plus"></i>
-      register
+      <span data-i18n="register">register</span>
     </div>
     <form action="" autocomplete="nope">
       <input
@@ -45,14 +45,14 @@
       />
       <button type="submit" disabled>
         <i class="fas fa-user-plus"></i>
-        sign up
+        <span data-i18n="register">sign up</span>
       </button>
     </form>
   </div>
   <div class="login side">
     <div class="title">
       <i class="fas fa-sign-in-alt"></i>
-      login
+      <span data-i18n="login">login</span>
     </div>
     <div class="providers">
       <button class="signInWithGoogle">

--- a/frontend/src/html/pages/settings.html
+++ b/frontend/src/html/pages/settings.html
@@ -325,6 +325,19 @@
         <select></select>
       </div>
     </div>
+    <div class="section" data-config-name="uiLanguage">
+      <div class="groupTitle">
+        <i class="fas fa-globe"></i>
+        <span data-i18n="uiLanguage">ui language</span>
+      </div>
+      <div class="text" data-i18n="uiLanguageDesc">Choose language of the interface.</div>
+      <div class="inputs">
+        <select>
+          <option value="en" data-i18n="langEnglish">English</option>
+          <option value="ru" data-i18n="langRussian">Russian</option>
+        </select>
+      </div>
+    </div>
     <div class="section fullWidth" data-config-name="funbox">
       <div class="groupTitle">
         <i class="fas fa-gamepad"></i>

--- a/frontend/src/ts/config.ts
+++ b/frontend/src/ts/config.ts
@@ -1575,6 +1575,20 @@ export function setLanguage(language: Language, nosave?: boolean): boolean {
   return true;
 }
 
+export function setUiLanguage(
+  language: ConfigSchemas.UiLanguage,
+  nosave?: boolean
+): boolean {
+  if (!isConfigValueValid("ui language", language, ConfigSchemas.UiLanguageSchema))
+    return false;
+
+  config.uiLanguage = language;
+  saveToLocalStorage("uiLanguage", nosave);
+  ConfigEvent.dispatch("uiLanguage", config.uiLanguage);
+
+  return true;
+}
+
 export function setMonkey(monkey: boolean, nosave?: boolean): boolean {
   if (!isConfigValueValidBoolean("monkey", monkey)) return false;
 
@@ -2024,6 +2038,7 @@ export async function apply(
     setQuoteLength(configObj.quoteLength, true);
     setWordCount(configObj.words, true);
     setLanguage(configObj.language, true);
+    setUiLanguage(configObj.uiLanguage, true);
     setLayout(configObj.layout, true);
     setFontSize(configObj.fontSize, true);
     setMaxLineWidth(configObj.maxLineWidth, true);

--- a/frontend/src/ts/constants/default-config.ts
+++ b/frontend/src/ts/constants/default-config.ts
@@ -34,6 +34,7 @@ const obj = {
   mode: "time",
   quoteLength: [1],
   language: "english",
+  uiLanguage: "en",
   fontSize: 2,
   freedomMode: false,
   difficulty: "normal",

--- a/frontend/src/ts/i18n/index.ts
+++ b/frontend/src/ts/i18n/index.ts
@@ -1,0 +1,32 @@
+import { UiLanguage } from "@monkeytype/contracts/schemas/configs";
+
+let translations: Record<string, string> = {};
+
+async function loadFile(lang: UiLanguage): Promise<Record<string, string>> {
+  switch (lang) {
+    case "ru":
+      return (await import("./ru.json")).default as Record<string, string>;
+    default:
+      return {};
+  }
+}
+
+export async function init(lang: UiLanguage): Promise<void> {
+  translations = await loadFile(lang);
+  applyTranslations();
+}
+
+export function t(key: string): string {
+  return translations[key] ?? key;
+}
+
+export function applyTranslations(root: HTMLElement = document.body): void {
+  const elements = root.querySelectorAll<HTMLElement>("[data-i18n]");
+  elements.forEach((el) => {
+    const key = el.getAttribute("data-i18n");
+    if (key) {
+      el.textContent = t(key);
+    }
+  });
+}
+

--- a/frontend/src/ts/i18n/ru.json
+++ b/frontend/src/ts/i18n/ru.json
@@ -1,0 +1,14 @@
+{
+  "startTest": "Начать тест",
+  "leaderboards": "Таблица лидеров",
+  "about": "О сайте",
+  "settings": "Настройки",
+  "goHome": "На главную",
+  "register": "Регистрация",
+  "login": "Вход",
+  "pageNotFound": "Упс! Страница не найдена.",
+  "uiLanguage": "Язык интерфейса",
+  "uiLanguageDesc": "Выберите язык сайта",
+  "langEnglish": "Английский",
+  "langRussian": "Русский"
+}

--- a/frontend/src/ts/index.ts
+++ b/frontend/src/ts/index.ts
@@ -20,7 +20,9 @@ import * as DB from "./db";
 import "./ui";
 import "./elements/settings/account-settings-notice";
 import "./controllers/ad-controller";
-import Config, { loadFromLocalStorage } from "./config";
+import Config, { loadFromLocalStorage, loadPromise } from "./config";
+import * as ConfigEvent from "./observables/config-event";
+import * as I18n from "./i18n";
 import * as TestStats from "./test/test-stats";
 import * as Replay from "./test/replay";
 import * as TestTimer from "./test/test-timer";
@@ -57,6 +59,14 @@ function addToGlobal(items: Record<string, unknown>): void {
 }
 
 void loadFromLocalStorage();
+void loadPromise.then(() => {
+  void I18n.init(Config.uiLanguage);
+});
+ConfigEvent.subscribe((key, value) => {
+  if (key === "uiLanguage") {
+    void I18n.init(value as any);
+  }
+});
 void VersionButton.update();
 Focus.set(true, true);
 

--- a/frontend/src/ts/pages/settings.ts
+++ b/frontend/src/ts/pages/settings.ts
@@ -331,6 +331,11 @@ async function initGroups(): Promise<void> {
     UpdateConfig.setLanguage,
     "select"
   ) as SettingsGroup<ConfigValue>;
+  groups["uiLanguage"] = new SettingsGroup(
+    "uiLanguage",
+    UpdateConfig.setUiLanguage,
+    "select"
+  ) as SettingsGroup<ConfigValue>;
   groups["fontSize"] = new SettingsGroup(
     "fontSize",
     UpdateConfig.setFontSize,
@@ -446,6 +451,13 @@ async function fillSettingsPage(): Promise<void> {
     settings: {
       searchPlaceholder: "search",
     },
+  });
+  new SlimSelect({
+    select: ".pageSettings .section[data-config-name='uiLanguage'] select",
+    data: [
+      { text: "English", value: "en", selected: Config.uiLanguage === "en" },
+      { text: "Russian", value: "ru", selected: Config.uiLanguage === "ru" },
+    ],
   });
 
   const layoutToOption: (layout: LayoutName) => OptionOptional = (layout) => ({
@@ -1344,6 +1356,14 @@ ConfigEvent.subscribe((eventKey, eventValue) => {
     $(
       `.pageSettings .section[data-config-name='autoSwitchThemeInputs'] select.dark option[value="${eventValue}"]`
     ).attr("selected", "true");
+  }
+  if (eventKey === "uiLanguage") {
+    const sel = document.querySelector(
+      ".pageSettings .section[data-config-name='uiLanguage'] select"
+    ) as HTMLSelectElement | null;
+    if (sel) {
+      sel.value = eventValue as string;
+    }
   }
   //make sure the page doesnt update a billion times when applying a preset/config at once
   if (configEventDisabled || eventKey === "saveToLocalStorage") return;

--- a/packages/contracts/src/schemas/configs.ts
+++ b/packages/contracts/src/schemas/configs.ts
@@ -4,6 +4,9 @@ import * as Themes from "./themes";
 import * as Layouts from "./layouts";
 import { LanguageSchema } from "./languages";
 
+export const UiLanguageSchema = z.enum(["en", "ru"]);
+export type UiLanguage = z.infer<typeof UiLanguageSchema>;
+
 export const SmoothCaretSchema = z.enum(["off", "slow", "medium", "fast"]);
 export type SmoothCaret = z.infer<typeof SmoothCaretSchema>;
 
@@ -364,6 +367,7 @@ export const ConfigSchema = z
     mode: Shared.ModeSchema,
     quoteLength: QuoteLengthConfigSchema,
     language: LanguageSchema,
+    uiLanguage: UiLanguageSchema,
     fontSize: FontSizeSchema,
     freedomMode: z.boolean(),
     difficulty: DifficultySchema,
@@ -478,6 +482,7 @@ export const ConfigGroupsLiteral = {
   mode: "test",
   quoteLength: "test",
   language: "test",
+  uiLanguage: "appearance",
   fontSize: "appearance",
   freedomMode: "input",
   difficulty: "behavior",


### PR DESCRIPTION
## Summary
- support UI language in config contracts
- include `uiLanguage` default value
- load translations on startup
- Russian translations module and DOM injection
- allow choosing UI language in settings
- localize some pages
- test i18n module

## Testing
- `pnpm --dir frontend test` *(fails: unsupported node engine)*

------
https://chatgpt.com/codex/tasks/task_e_68417c8379208332bf53f60cd30420c4